### PR TITLE
Guess domain name with hyphen(s) correctly

### DIFF
--- a/R/parse_url.R
+++ b/R/parse_url.R
@@ -28,7 +28,7 @@
 #'
 parse_url <- function(url){
   match <-
-    stringr::str_match(url, "(^\\w+://)?([\\w.]+)?(/.*)?")[, -1, drop = FALSE]
+    stringr::str_match(url, "(^\\w+://)?([\\w.-]+)?(/.*)?")[, -1, drop = FALSE]
 
   df        <- as.data.frame(match, stringsAsFactors = FALSE)
   names(df) <- c("protocol", "domain", "path")

--- a/tests/testthat/test_tools.R
+++ b/tests/testthat/test_tools.R
@@ -99,6 +99,13 @@ test_that(
       guess_domain("www.google.com") == "www.google.com"
     })
 
+    expect_true({
+      guess_domain("www.domain-with-hyphen.tld") == "www.domain-with-hyphen.tld"
+    })
+
+    expect_true({
+      guess_domain("tld-domain.tld") == "tld-domain.tld"
+    })
 
   }
 )


### PR DESCRIPTION
Hi! In v0.7.7, `robotstxt:::guess_domain("www.some-domain.com")` returns `www.some`, also when prefixing `http(s)://` or suffixing `/some/path/index.html`.

I suggest to rely on a more common [parse_url.R](https://github.com/ropensci/robotstxt/blame/a57b5c91690646c661c15194527ff5d904d07000/R/parse_url.R#L31) variant. Maybe from [httr](https://httr.r-lib.org/reference/parse_url.html)?

This is a quick attempt to integrate the bug fix. Please feel free to take it where you feel it's best.