### PR TITLE
Repair parsing error due to commented-out field token

### DIFF
--- a/inst/robotstxts/robots_commented_token.txt
+++ b/inst/robotstxts/robots_commented_token.txt
@@ -1,0 +1,7 @@
+User-agent: bot_1
+Disallow: /path_1
+
+# User-agent: bot_2
+# Disallow: /path_2
+
+# Sitemap: /sitemap.php

--- a/tests/testthat/test_parser.R
+++ b/tests/testthat/test_parser.R
@@ -25,6 +25,7 @@ rtxt_fb_nsp  <- rt_get_rtxt("robots_facebook_unsupported.txt")
 rtxt_cdc     <- rt_get_rtxt("robots_cdc.txt")
 rtxt_cdc2    <- paste(rt_get_rtxt("robots_cdc2.txt"), collapse = "\r\n")
 rtxt_rbloggers     <- rt_get_rtxt("rbloggers.txt")
+rtxt_ct      <- rt_get_rtxt("robots_commented_token.txt")
 
 test_that(
   "all robots.txt files are valid", {
@@ -117,6 +118,10 @@ test_that(
 
     expect_true(
       is_valid_robotstxt( rtxt_cdc )
+    )
+
+    expect_true(
+      is_valid_robotstxt( rtxt_ct )
     )
   })
 
@@ -213,6 +218,15 @@ test_that(
   }
 )
 
+context("Commented-out tokens get parsed correctly")
+
+test_that(
+  "Commented-out tokens get ignored", {
+    expect_true(
+      nrow(parse_robotstxt(rtxt_ct)$permissions) == 1
+    )
+  }
+)
 
 
 


### PR DESCRIPTION
When a line starts with `#` but continues with one of the valid fields / tokens, this backtrace is produced:

```r
Error: Test failed: 'Commented-out tokens get parsed correctly'
* 'names' attribute [2] must be the same length as the vector [0]
Backtrace:
 1. testthat::expect_true(...)
 5. robotstxt::parse_robotstxt(rtxt_ct)
 6. robotstxt::rt_get_fields(txt, "allow") …robotstxtRparse_robotstxt.R:7:2
 7. base::lapply(...) …robotstxtRrt_get_fields.R:38:2
 8. robotstxt:::FUN(X[[i]], ...)
```

After removing the `#` in this demo `.txt`, the test case will fail with `nrow(parse_robotstxt(rtxt_ct)$permissions) == 1 isn't true.` which I take that the error is avoided.

Maybe the error results from somewhere in [rt_get_fields.R](https://github.com/ropensci/robotstxt/blob/26492725fdbff4bed5bc946ed5c7c2519cd5e012/R/rt_get_fields_worker.R#L11-L32)? Maybe because one of the reg-exes detects the valid token (`[2]`), but another detects the line as a comment (`[0]`), thus clashing at `names(fields) <- c("field", "value")`?

I've tinkered with the various reg-exes there for about an hour, but found no solution. Will instead remove the problematic file from my analysis to continue with that for now.

Please feel free to take over the PR. I hope the test is a useful start to find and fix the problem.