### PR TITLE
Add `covr` code coverage

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,61 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: test-coverage.yaml
+
+permissions: read-all
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::covr, any::xml2
+          needs: coverage
+
+      - name: Test coverage
+        run: |
+          cov <- covr::package_coverage(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
+          covr::to_cobertura(cov)
+        shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
+          file: ./cobertura.xml
+          plugin: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package

--- a/README.Rmd
+++ b/README.Rmd
@@ -50,6 +50,7 @@ length.cpp   <- length(grep("(^\\s*$)|(^\\s*#)|(^\\s*//)", lines.cpp,  value = T
 [![Total Downloads](https://cranlogs.r-pkg.org/badges/grand-total/robotstxt)](https://cran.r-project.org/web/packages/robotstxt/index.html)
 [![Cran Checks](https://badges.cranchecks.info/summary/robotstxt.svg)](https://cran.r-project.org/web/checks/check_results_robotstxt.html)
 [![Lifecycle: Stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
+[![Codecov test coverage](https://codecov.io/gh/ropensci/robotstxt/graph/badge.svg)](https://app.codecov.io/gh/ropensci/robotstxt)
 <!-- badges: end -->
 
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 
 Permissions Checker
 
-[![ropensci\_footer](https://raw.githubusercontent.com/ropensci/robotstxt/master/logo/github_footer.png)](https://ropensci.org)
+[![ropensci_footer](https://raw.githubusercontent.com/ropensci/robotstxt/master/logo/github_footer.png)](https://ropensci.org)
 
 **Status**
 
-*lines of R code:* 1007, *lines of test code:* 1758
+*lines of R code:* 1007, *lines of test code:* 1760
 
 <!-- badges: start -->
 
@@ -22,11 +22,13 @@ Downloads](https://cranlogs.r-pkg.org/badges/grand-total/robotstxt)](https://cra
 Checks](https://badges.cranchecks.info/summary/robotstxt.svg)](https://cran.r-project.org/web/checks/check_results_robotstxt.html)
 [![Lifecycle:
 Stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
+[![Codecov test
+coverage](https://codecov.io/gh/ropensci/robotstxt/graph/badge.svg)](https://app.codecov.io/gh/ropensci/robotstxt)
 <!-- badges: end -->
 
 **Development version**
 
-0.7.13 - 2024-08-19 / 23:13:05
+0.7.13 - 2024-08-27 / 16:49:41
 
 **Description**
 
@@ -37,7 +39,7 @@ the package makes it easy to check if bots (spiders, crawler, scrapers,
 **License**
 
 MIT + file LICENSE <br>Peter Meissner \[aut, cre\], Kun Ren \[aut, cph\]
-(Author and copyright holder of list\_merge.R.), Oliver Keys \[ctb\]
+(Author and copyright holder of list_merge.R.), Oliver Keys \[ctb\]
 (original release code review), Rich Fitz John \[ctb\] (original release
 code review)
 
@@ -63,28 +65,28 @@ terms:
 > all people who contribute through reporting issues, posting feature
 > requests, updating documentation, submitting pull requests or patches,
 > and other activities.
-> 
+>
 > We are committed to making participation in this project a
 > harassment-free experience for everyone, regardless of level of
 > experience, gender, gender identity and expression, sexual
 > orientation, disability, personal appearance, body size, race,
 > ethnicity, age, or religion.
-> 
+>
 > Examples of unacceptable behavior by participants include the use of
 > sexual language or imagery, derogatory comments or personal attacks,
 > trolling, public or private harassment, insults, or other
 > unprofessional conduct.
-> 
+>
 > Project maintainers have the right and responsibility to remove, edit,
 > or reject comments, commits, code, wiki edits, issues, and other
 > contributions that are not aligned to this Code of Conduct. Project
 > maintainers who do not follow the Code of Conduct may be removed from
 > the project team.
-> 
+>
 > Instances of abusive, harassing, or otherwise unacceptable behavior
 > may be reported by opening an issue or contacting one or more of the
 > project maintainers.
-> 
+>
 > This Code of Conduct is adapted from the Contributor Covenant
 > (<https://www.contributor-covenant.org/>), version 1.0.0, available at
 > <https://www.contributor-covenant.org/version/1/0/0/code-of-conduct/>
@@ -127,9 +129,6 @@ paths_allowed(
 )
 ##  wikipedia.org
 ## [1]  TRUE FALSE
-```
-
-``` r
 
 paths_allowed(
   paths = c(
@@ -188,18 +187,17 @@ edges.
 
 Some interpretation problems:
 
-  - finding no robots.txt file at the server (e.g. HTTP status code 404)
-    implies that everything is allowed
-  - subdomains should have there own robots.txt file if not it is
-    assumed that everything is allowed
-  - redirects involving protocol changes - e.g. upgrading from http to
-    https - are followed and considered no domain or subdomain change -
-    so whatever is found at the end of the redirect is considered to be
-    the robots.txt file for the original domain
-  - redirects from subdomain www to the doamin is considered no domain
-    change - so whatever is found at the end of the redirect is
-    considered to be the robots.txt file for the subdomain originally
-    requested
+- finding no robots.txt file at the server (e.g. HTTP status code 404)
+  implies that everything is allowed
+- subdomains should have there own robots.txt file if not it is assumed
+  that everything is allowed
+- redirects involving protocol changes - e.g. upgrading from http to
+  https - are followed and considered no domain or subdomain change - so
+  whatever is found at the end of the redirect is considered to be the
+  robots.txt file for the original domain
+- redirects from subdomain www to the doamin is considered no domain
+  change - so whatever is found at the end of the redirect is considered
+  to be the robots.txt file for the subdomain originally requested
 
 ### Event Handling
 
@@ -215,13 +213,13 @@ in its content. If an event/state happened the event handlers are passed
 on to the `request_handler_handler()` along for problem resolution and
 collecting robots.txt file transformations:
 
-  - rule priorities decide if rules are applied given the current state
-    priority
-  - if rules specify signals those are emitted (e.g. error, message,
-    warning)
-  - often rules imply overwriting the raw content with a suitable
-    interpretation given the circumstances the file was (or was not)
-    retrieved
+- rule priorities decide if rules are applied given the current state
+  priority
+- if rules specify signals those are emitted (e.g. error, message,
+  warning)
+- often rules imply overwriting the raw content with a suitable
+  interpretation given the circumstances the file was (or was not)
+  retrieved
 
 Event handler rules can either consist of 4 items or can be functions -
 the former being the usual case and that used throughout the package
@@ -230,29 +228,27 @@ passing along handler rules or handler functions.
 
 Handler rules are lists with the following items:
 
-  - `over_write_file_with`: if the rule is triggered and has higher
-    priority than those rules applied beforehand (i.e. the new priority
-    has an higher value than the old priority) than the robots.txt file
-    retrieved will be overwritten by this character vector
-  - `signal`: might be `"message"`, `"warning"`, or `"error"` and will
-    use the signal function to signal the event/state just handled.
-    Signaling a warning or a message might be suppressed by setting the
-    function paramter `warn = FALSE`.
-  - `cache` should the package be allowed to cache the results of the
-    retrieval or not
-  - `priority` the priority of the rule specified as numeric value,
-    rules with higher priority will be allowed to overwrite robots.txt
-    file content changed by rules with lower priority
+- `over_write_file_with`: if the rule is triggered and has higher
+  priority than those rules applied beforehand (i.e. the new priority
+  has an higher value than the old priority) than the robots.txt file
+  retrieved will be overwritten by this character vector
+- `signal`: might be `"message"`, `"warning"`, or `"error"` and will use
+  the signal function to signal the event/state just handled. Signaling
+  a warning or a message might be suppressed by setting the function
+  paramter `warn = FALSE`.
+- `cache` should the package be allowed to cache the results of the
+  retrieval or not
+- `priority` the priority of the rule specified as numeric value, rules
+  with higher priority will be allowed to overwrite robots.txt file
+  content changed by rules with lower priority
 
 The package knows the following rules with the following defaults:
 
-  - `on_server_error` :
-  - given a server error - the server is unable to serve a file - we
-    assume that something is terrible wrong and forbid all paths for the
-    time being but do not cache the result so that we might get an
-    updated file later on
-
-<!-- end list -->
+- `on_server_error` :
+- given a server error - the server is unable to serve a file - we
+  assume that something is terrible wrong and forbid all paths for the
+  time being but do not cache the result so that we might get an updated
+  file later on
 
 ``` r
 on_server_error_default
@@ -269,17 +265,15 @@ on_server_error_default
 ## [1] 20
 ```
 
-  - `on_client_error` :
-  - client errors encompass all HTTP status 4xx status codes except 404
-    which is handled directly
-  - despite the fact that there are a lot of codes that might indicate
-    that the client has to take action (authentication, billing, … see:
-    <https://de.wikipedia.org/wiki/HTTP-Statuscode>) in the case of
-    retrieving robots.txt with simple GET request things should just
-    work and any client error is treated as if there is no file
-    available and thus scraping is generally allowed
-
-<!-- end list -->
+- `on_client_error` :
+- client errors encompass all HTTP status 4xx status codes except 404
+  which is handled directly
+- despite the fact that there are a lot of codes that might indicate
+  that the client has to take action (authentication, billing, … see:
+  <https://de.wikipedia.org/wiki/HTTP-Statuscode>) in the case of
+  retrieving robots.txt with simple GET request things should just work
+  and any client error is treated as if there is no file available and
+  thus scraping is generally allowed
 
 ``` r
 on_client_error_default
@@ -296,12 +290,10 @@ on_client_error_default
 ## [1] 19
 ```
 
-  - `on_not_found` :
-  - HTTP status code 404 has its own handler but is treated the same
-    ways other client errors: if there is no file available and thus
-    scraping is generally allowed
-
-<!-- end list -->
+- `on_not_found` :
+- HTTP status code 404 has its own handler but is treated the same ways
+  other client errors: if there is no file available and thus scraping
+  is generally allowed
 
 ``` r
 on_not_found_default
@@ -318,12 +310,9 @@ on_not_found_default
 ## [1] 1
 ```
 
-  - `on_redirect` :
-  - redirects are ok - often redirects redirect from HTTP schema to
-    HTTPS - robotstxt will use whatever content it has been redirected
-    to
-
-<!-- end list -->
+- `on_redirect` :
+- redirects are ok - often redirects redirect from HTTP schema to
+  HTTPS - robotstxt will use whatever content it has been redirected to
 
 ``` r
 on_redirect_default
@@ -334,11 +323,9 @@ on_redirect_default
 ## [1] 3
 ```
 
-  - `on_domain_change` :
-  - domain changes are handled as if the robots.txt file did not exist
-    and thus scraping is generally allowed
-
-<!-- end list -->
+- `on_domain_change` :
+- domain changes are handled as if the robots.txt file did not exist and
+  thus scraping is generally allowed
 
 ``` r
 on_domain_change_default
@@ -352,12 +339,10 @@ on_domain_change_default
 ## [1] 4
 ```
 
-  - `on_file_type_mismatch` :
-  - if {robotstxt} gets content with content type other than text it
-    probably is not a robotstxt file, this situation is handled as if no
-    file was provided and thus scraping is generally allowed
-
-<!-- end list -->
+- `on_file_type_mismatch` :
+- if {robotstxt} gets content with content type other than text it
+  probably is not a robotstxt file, this situation is handled as if no
+  file was provided and thus scraping is generally allowed
 
 ``` r
 on_file_type_mismatch_default
@@ -374,12 +359,10 @@ on_file_type_mismatch_default
 ## [1] 6
 ```
 
-  - `on_suspect_content` :
-  - if {robotstxt} cannot parse it probably is not a robotstxt file,
-    this situation is handled as if no file was provided and thus
-    scraping is generally allowed
-
-<!-- end list -->
+- `on_suspect_content` :
+- if {robotstxt} cannot parse it probably is not a robotstxt file, this
+  situation is handled as if no file was provided and thus scraping is
+  generally allowed
 
 ``` r
 on_suspect_content_default
@@ -408,42 +391,42 @@ the interpretation of permissions granted.
 
 **Features and Problems handled:**
 
-  - now handles corner cases of retrieving robots.txt files
-  - e.g. if no robots.txt file is available this basically means “you
-    can scrape it all”
-  - but there are further corner cases (what if there is a server error,
-    what if redirection takes place, what is redirection takes place to
-    different domains, what if a file is returned but it is not
-    parsable, or is of format HTML or JSON, …)
+- now handles corner cases of retrieving robots.txt files
+- e.g. if no robots.txt file is available this basically means “you can
+  scrape it all”
+- but there are further corner cases (what if there is a server error,
+  what if redirection takes place, what is redirection takes place to
+  different domains, what if a file is returned but it is not parsable,
+  or is of format HTML or JSON, …)
 
 **Design Decisions**
 
 1.  the whole HTTP request-response-chain is checked for certain
     event/state types
-      - server error
-      - client error
-      - file not found (404)
-      - redirection
-      - redirection to another domain
+    - server error
+    - client error
+    - file not found (404)
+    - redirection
+    - redirection to another domain
 2.  the content returned by the HTTP is checked against
-      - mime type / file type specification mismatch
-      - suspicious content (file content does seem to be JSON, HTML, or
-        XML instead of robots.txt)
+    - mime type / file type specification mismatch
+    - suspicious content (file content does seem to be JSON, HTML, or
+      XML instead of robots.txt)
 3.  state/event handler define how these states and events are handled
 4.  a handler handler executes the rules defined in individual handlers
 5.  handler can be overwritten
 6.  handler defaults are defined that they should always do the right
     thing
 7.  handler can …
-      - overwrite the content of a robots.txt file (e.g. allow/disallow
-        all)
-      - modify how problems should be signaled: error, warning, message,
-        none
-      - if robots.txt file retrieval should be cached or not
+    - overwrite the content of a robots.txt file (e.g. allow/disallow
+      all)
+    - modify how problems should be signaled: error, warning, message,
+      none
+    - if robots.txt file retrieval should be cached or not
 8.  problems (no matter how they were handled) are attached to the
     robots.txt’s as attributes, allowing for …
-      - transparency
-      - reacting post-mortem to the problems that occured
+    - transparency
+    - reacting post-mortem to the problems that occured
 9.  all handler (even the actual execution of the HTTP-request) can be
     overwritten at runtime to inject user defined behaviour beforehand
 
@@ -452,9 +435,9 @@ the interpretation of permissions granted.
 By default all functions retrieving robots.txt files will warn if there
 are
 
-  - any HTTP events happening while retrieving the file (e.g. redirects)
-    or
-  - the content of the file does not seem to be a valid robots.txt file.
+- any HTTP events happening while retrieving the file (e.g. redirects)
+  or
+- the content of the file does not seem to be a valid robots.txt file.
 
 The warnings in the following example can be turned of in three ways:
 
@@ -512,9 +495,6 @@ rt <-
 
 as.character(rt)
 ## [1] "# just do it - punk\n"
-```
-
-``` r
 
 cat(rt)
 ## # just do it - punk
@@ -525,7 +505,7 @@ The last HTTP request is stored in an object
 ``` r
 rt_last_http$request
 ## Response [https://petermeissner.de/robots.txt]
-##   Date: 2024-08-19 23:48
+##   Date: 2024-08-28 21:00
 ##   Status: 200
 ##   Content-Type: text/plain
 ##   Size: 20 B
@@ -567,7 +547,7 @@ was going on in the client-server exchange.
 ``` r
 attr(rt, "request")
 ## Response [https://petermeissner.de/robots.txt]
-##   Date: 2024-08-19 23:48
+##   Date: 2024-08-28 21:00
 ##   Status: 200
 ##   Content-Type: text/plain
 ##   Size: 20 B
@@ -599,15 +579,12 @@ rt_req$request
 ## GET http://petermeissner.de/robots.txt
 ## Output: write_memory
 ## Options:
-## * useragent: libcurl/7.81.0 r-curl/5.2.1 httr/1.4.7
+## * useragent: libcurl/7.81.0 r-curl/5.2.2 httr/1.4.7
 ## * ssl_verifypeer: 1
 ## * httpget: TRUE
 ## Headers:
 ## * Accept: application/json, text/xml, application/xml, */*
 ## * user-agent: R version 4.4.1 (2024-06-14)
-```
-
-``` r
 
 # response headers
 rt_req$all_headers
@@ -623,7 +600,7 @@ rt_req$all_headers
 ## [1] "nginx/1.10.3 (Ubuntu)"
 ## 
 ## $date
-## [1] "Mon, 19 Aug 2024 23:48:37 GMT"
+## [1] "Wed, 28 Aug 2024 21:00:36 GMT"
 ## 
 ## $`content-type`
 ## [1] "text/html"
@@ -653,7 +630,7 @@ rt_req$all_headers
 ## [1] "nginx/1.10.3 (Ubuntu)"
 ## 
 ## $date
-## [1] "Mon, 19 Aug 2024 23:48:38 GMT"
+## [1] "Wed, 28 Aug 2024 21:00:36 GMT"
 ## 
 ## $`content-type`
 ## [1] "text/plain"
@@ -712,7 +689,7 @@ as.list(rt)
 ## 
 ## $request
 ## Response [https://petermeissner.de/robots.txt]
-##   Date: 2024-08-19 23:48
+##   Date: 2024-08-28 21:00
 ##   Status: 200
 ##   Content-Type: text/plain
 ##   Size: 20 B
@@ -730,9 +707,6 @@ the robots.txt file.
 paths_allowed("petermeissner.de/I_want_to_scrape_this_now", force = TRUE, verbose = TRUE)
 ##  petermeissner.de                      rt_robotstxt_http_getter: force http get
 ## [1] TRUE
-```
-
-``` r
 paths_allowed("petermeissner.de/I_want_to_scrape_this_now",verbose = TRUE)
 ##  petermeissner.de                      rt_robotstxt_http_getter: cached http get
 ## [1] TRUE
@@ -740,11 +714,11 @@ paths_allowed("petermeissner.de/I_want_to_scrape_this_now",verbose = TRUE)
 
 ## More information
 
-  - <https://www.robotstxt.org/norobots-rfc.txt>
-  - [Have a look at the vignette at
-    https://cran.r-project.org/package=robotstxt/vignettes/using\_robotstxt.html](https://cran.r-project.org/package=robotstxt/vignettes/using_robotstxt.html)
-  - [Google on
-    robots.txt](https://developers.google.com/search/reference/robots_txt?hl=en)
-  - <https://wiki.selfhtml.org/wiki/Grundlagen/Robots.txt>
-  - <https://support.google.com/webmasters/answer/6062608?hl=en>
-  - <https://www.robotstxt.org/robotstxt.html>
+- <https://www.robotstxt.org/norobots-rfc.txt>
+- [Have a look at the vignette at
+  https://cran.r-project.org/package=robotstxt/vignettes/using_robotstxt.html](https://cran.r-project.org/package=robotstxt/vignettes/using_robotstxt.html)
+- [Google on
+  robots.txt](https://developers.google.com/search/reference/robots_txt?hl=en)
+- <https://wiki.selfhtml.org/wiki/Grundlagen/Robots.txt>
+- <https://support.google.com/webmasters/answer/6062608?hl=en>
+- <https://www.robotstxt.org/robotstxt.html>


### PR DESCRIPTION
Closes #85. Most `README` changes not related to the `covr` badge seem to be due to changes in `knitr` versions. #84 provides a major update to the documentation anyway, so I will merge.